### PR TITLE
Fix CI: Add src to Python path for module imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # Install project dependencies
-        pip install pandas numpy scikit-learn matplotlib seaborn lightgbm imbalanced-learn shap pytest nbconvert
+        # Install project dependencies from requirements.txt
+        pip install -r requirements.txt
         # nbconvert is needed to execute notebooks
 
     - name: Create data directory and copy placeholder data
      
+      # For CI, we'll create dummy files to ensure the notebooks can load them
+      # without failing due to missing files.
       run: |
         mkdir -p data
         # Create dummy CSV files if they don't exist, so notebooks can load them
@@ -45,6 +47,9 @@ jobs:
         echo "0.0,-0.1,-0.2,-0.3,-0.4,-0.5,-0.6,-0.7,-0.8,-0.9,-1.0,-1.1,-1.2,-1.3,-1.4,-1.5,-1.6,-1.7,-1.8,-1.9,-2.0,-2.1,-2.2,-2.3,-2.4,-2.5,-2.6,-2.7,-2.8,10.0,0" >> data/creditcard.csv
         echo "1.0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8,20.0,1" >> data/creditcard.csv
 
+    - name: Add src to Python Path
+      # This ensures Python can find your modules when running tests and notebooks
+      run: echo "PYTHONPATH=$(pwd)/src" >> $GITHUB_ENV
 
     - name: Run Unit Tests
       run: |
@@ -71,4 +76,4 @@ jobs:
           eda_executed.ipynb
           modeling_executed.ipynb
           explainability_executed.ipynb
-      if: always() 
+      if: always()


### PR DESCRIPTION
This PR resolves ModuleNotFoundError in CI by explicitly adding the src/ directory to PYTHONPATH.
Ensures successful execution of tests and notebooks in GitHub Actions.